### PR TITLE
Feature: Support Request(String)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 An AWS Signature Version 4 client implementation, useful for making
 authenticated requests to services such as AWS S3.
 
+For more information on the AWS v4 signature see: [Create a signed AWS API request](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html).
+
 [![Package Version](https://img.shields.io/hexpm/v/aws4_request)](https://hex.pm/packages/aws4_request)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/aws4_request/)
+
+Supports authentication with [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) credentials.
 
 ```sh
 gleam add aws4_request
 ```
+
 ```gleam
 import gleam/httpc
 import aws4_request
@@ -29,10 +34,10 @@ pub fn main() {
   let request =
     request
     |> request.set_method(http.Get)
-    |> request.set_body(<<>>)
+    |> request.set_body("")
 
   let signed_request =
-    aws4_request.sign(
+    aws4_request.sign_string(
       request,
       date_time,
       access_key_id,

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "aws4_request"
-version = "0.1.1"
+version = "0.2.0"
 gleam = ">= 0.32.0"
 description = "An AWS Signature Version 4 client implementation, used for S3 auth, etc"
 

--- a/src/aws4_request.gleam
+++ b/src/aws4_request.gleam
@@ -9,9 +9,8 @@ import gleam/string
 
 // TODO: document
 // TODO: document params
-// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
-// https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
-pub fn sign(
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+pub fn sign_bits(
   request request: Request(BitArray),
   date_time date_time: #(#(Int, Int, Int), #(Int, Int, Int)),
   access_key_id access_key_id: String,
@@ -19,10 +18,48 @@ pub fn sign(
   region region: String,
   service service: String,
 ) -> Request(BitArray) {
+  sign(
+    request,
+    request.body,
+    date_time,
+    access_key_id,
+    secret_access_key,
+    region,
+    service,
+  )
+}
+
+pub fn sign_string(
+  request request: Request(String),
+  date_time date_time: #(#(Int, Int, Int), #(Int, Int, Int)),
+  access_key_id access_key_id: String,
+  secret_access_key secret_access_key: String,
+  region region: String,
+  service service: String,
+) -> Request(String) {
+  let body_as_bit_array = bit_array.from_string(request.body)
+  sign(
+    request,
+    body_as_bit_array,
+    date_time,
+    access_key_id,
+    secret_access_key,
+    region,
+    service,
+  )
+}
+
+fn sign(
+  request request: Request(a),
+  body body: BitArray,
+  date_time date_time: #(#(Int, Int, Int), #(Int, Int, Int)),
+  access_key_id access_key_id: String,
+  secret_access_key secret_access_key: String,
+  region region: String,
+  service service: String,
+) -> Request(a) {
   let payload_hash =
-    string.lowercase(
-      bit_array.base16_encode(crypto.hash(crypto.Sha256, request.body)),
-    )
+    string.lowercase(bit_array.base16_encode(crypto.hash(crypto.Sha256, body)))
 
   let #(#(year, month, day), #(hour, minute, second)) = date_time
   let date =

--- a/test/aws4_request_test.gleam
+++ b/test/aws4_request_test.gleam
@@ -8,18 +8,24 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn sign_test() {
-  let access_key_id = "AKIDEXAMPLE"
-  let secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-  let region = "us-east-1"
-  let service = "iam"
-  let date_time = #(#(2015, 8, 30), #(12, 36, 0))
-  let url = "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"
-  let input_headers = [
-    #("host", "iam.amazonaws.com"),
-    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
-  ]
+const access_key_id = "AKIDEXAMPLE"
 
+const secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+
+const region = "us-east-1"
+
+const service = "iam"
+
+const date_time = #(#(2015, 8, 30), #(12, 36, 0))
+
+const url = "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"
+
+const input_headers = [
+  #("host", "iam.amazonaws.com"),
+  #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+]
+
+pub fn sign_bits_test() {
   let assert Ok(request) = request.to(url)
   let request = request.Request(..request, headers: input_headers)
   let request =
@@ -28,7 +34,7 @@ pub fn sign_test() {
     |> request.set_body(<<>>)
 
   let signed_request =
-    aws4_request.sign(
+    aws4_request.sign_bits(
       request,
       date_time,
       access_key_id,
@@ -36,7 +42,60 @@ pub fn sign_test() {
       region,
       service,
     )
+  let expected_headers = [
+    #(
+      "authorization",
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request,SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947",
+    ),
+    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+    #("host", "iam.amazonaws.com"),
+    #(
+      "x-amz-content-sha256",
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    ),
+    #("x-amz-date", "20150830T123600Z"),
+  ]
+  validate_request(request, signed_request, expected_headers)
+}
 
+pub fn sign_string_test() {
+  let assert Ok(request) = request.to(url)
+  let request = request.Request(..request, headers: input_headers)
+  let request =
+    request
+    |> request.set_method(http.Get)
+    |> request.set_body("")
+
+  let signed_request =
+    aws4_request.sign_string(
+      request,
+      date_time,
+      access_key_id,
+      secret_access_key,
+      region,
+      service,
+    )
+  let expected_headers = [
+    #(
+      "authorization",
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request,SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947",
+    ),
+    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+    #("host", "iam.amazonaws.com"),
+    #(
+      "x-amz-content-sha256",
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    ),
+    #("x-amz-date", "20150830T123600Z"),
+  ]
+  validate_request(request, signed_request, expected_headers)
+}
+
+fn validate_request(
+  request: request.Request(a),
+  signed_request: request.Request(a),
+  expected_headers: List(#(String, String)),
+) {
   signed_request.body
   |> should.equal(request.body)
 
@@ -59,17 +118,5 @@ pub fn sign_test() {
   |> should.equal(request.port)
 
   signed_request.headers
-  |> should.equal([
-    #(
-      "authorization",
-      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request,SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947",
-    ),
-    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
-    #("host", "iam.amazonaws.com"),
-    #(
-      "x-amz-content-sha256",
-      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    ),
-    #("x-amz-date", "20150830T123600Z"),
-  ])
+  |> should.equal(expected_headers)
 }


### PR DESCRIPTION
# Overview
Splitting individual features from https://github.com/lpil/aws4_request/pull/1 into individual pull requests.

It appears that there is not yet an [AWS SDK](https://aws.amazon.com/developer/tools/) for Gleam, and making AWS API requests directly is non-trivial because each request must be signed with [AWS Signature V4](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html) which is time consuming to implement from scratch.
My hope is to contribute a new AWS SDK package for Gleam which will hopefully be beneficial to the community.

Before doing that I wanted to ensure this package supports [temporary credentials (session token)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) in addition to the access keys it already supports.  

# New Features
- Added method to support `Request(String)` as well as the existing `Request(BitArray)`

The previous example in the `README.md` will not work with the current latest version of `gleam_httpc`:
```
  let request = // type Request(BitArray)
    request
    |> request.set_method(http.Get)
    |> request.set_body(<<>>)

  let signed_request = // type Request(BitArray)
    aws4_request.sign(
      request,
      date_time,
      access_key_id,
      secret_access_key,
      region,
      service,
    )

  httpc.send(signed_request)  // only accepts type Request(String)
```

I resolved this by updating the type of request to be `Request(String)` but could also be done by updating the last line to:
`  httpc.send_bits(signed_request)`.

See the discussion on Request types and signing function names below for more details.

## Version Revision
Technically this should be a major revision to `1.0.0` due to changes to the public API, but also open to making it a minor revision since this package is not yet "stable".
Major - [Breaking changes to public API](https://semver.org/)

Previously this package had a single public API in `sign` which accepted only `Request(BitArray)`.  Based on the [gleam_httpc package](https://hexdocs.pm/gleam_httpc/gleam/httpc.html#send) appears that `Request(String)` is also a common type convention which could be supported.

`gleam_httpc` distinguishes between the two public APIs by having:
- `send`: `Request(String)`
- `send_bits`: `Request(BitArray)`

Unfortunately here the convention is reversed in the main branch where `sign` is `Request(BitArray)`, so it cannot be matching without breaking changes to the public API.  This update has the following public APIs:
- `sign_string`: `Request(String)`  (`sign` would also work here)
- `sign_bits`: `Request(BitArray)`

I'm erring on the side of explicit names and I don't know enough to say if String and BitArray are the only types of Requests that may be used in case there are others.  I also am unsure if there is a sane "default" type.

## Testing
Split single test into two tests to cover the two supported types of `Request`.  
Refactored some common functionality into constants and a `validate_request` method to reduce code replication.
