### PR TITLE
Allow passing session_token for temporary credentials

### DIFF
--- a/test/aws4_request_test.gleam
+++ b/test/aws4_request_test.gleam
@@ -1,6 +1,7 @@
 import aws4_request
 import gleam/http
 import gleam/http/request
+import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 
@@ -66,6 +67,70 @@ pub fn sign_test() {
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     ),
     #("x-amz-date", "20150830T123600Z"),
+  ])
+}
+
+pub fn sign_with_session_token_test() {
+  let access_key_id = "AKIDEXAMPLE"
+  let secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+  let session_token = "IQ+tiYg/O1"
+  let region = "us-east-1"
+  let service = "iam"
+  let date_time = #(#(2015, 8, 30), #(12, 36, 0))
+  let url = "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"
+  let input_headers = [
+    #("host", "iam.amazonaws.com"),
+    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+  ]
+
+  let assert Ok(request) = request.to(url)
+  let request = request.Request(..request, headers: input_headers)
+  let request =
+    request
+    |> request.set_method(http.Get)
+    |> request.set_body(<<>>)
+
+  let signed_request =
+    aws4_request.signer(access_key_id:, secret_access_key:, region:, service:)
+    |> aws4_request.with_date_time(date_time)
+    |> aws4_request.with_session_token(session_token)
+    |> aws4_request.sign_bits(request)
+
+  signed_request.body
+  |> should.equal(request.body)
+
+  signed_request.method
+  |> should.equal(request.method)
+
+  signed_request.path
+  |> should.equal(request.path)
+
+  signed_request.query
+  |> should.equal(request.query)
+
+  signed_request.scheme
+  |> should.equal(request.scheme)
+
+  signed_request.host
+  |> should.equal(request.host)
+
+  signed_request.port
+  |> should.equal(request.port)
+
+  signed_request.headers
+  |> should.equal([
+    #(
+      "authorization",
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request,SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token,Signature=5f5383bc82b5a1a7f3b4d6cf0fb4c1ed6cf79269de64111085f95738c5c5e137",
+    ),
+    #("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+    #("host", "iam.amazonaws.com"),
+    #(
+      "x-amz-content-sha256",
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    ),
+    #("x-amz-date", "20150830T123600Z"),
+    #("x-amz-security-token", session_token),
   ])
 }
 


### PR DESCRIPTION
Some APIs (like ours) only accept temporary credentials. They need to be rotated everyday. To allow this we need to include a ` session_token` in the headers and the sigv4 signature.

This adds support for passing a session_token.