### PR TITLE
add now js ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ authenticated requests to services such as AWS S3.
 
 [![Package Version](https://img.shields.io/hexpm/v/aws4_request)](https://hex.pm/packages/aws4_request)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/aws4_request/)
+![Erlang-compatible](https://img.shields.io/badge/target-erlang-a2003e)
+![JavaScript-compatible](https://img.shields.io/badge/target-javascript-f1e05a)
 
 ```sh
 gleam add aws4_request
 ```
+
 ```gleam
 import gleam/httpc
 import aws4_request

--- a/src/aws4_request.gleam
+++ b/src/aws4_request.gleam
@@ -199,6 +199,7 @@ pub fn sign_bits(
   Request(..request, headers: headers)
 }
 
+@external(javascript, "./now_ffi.mjs", "now")
 fn now() -> DateTime {
   system_time(1000) |> system_time_to_universal_time(1000)
 }

--- a/src/now_ffi.mjs
+++ b/src/now_ffi.mjs
@@ -1,0 +1,7 @@
+export function now() {
+  const date = new Date();
+  return [
+    [date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()],
+    [date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds()],
+  ];
+}

--- a/test/aws4_request_test.gleam
+++ b/test/aws4_request_test.gleam
@@ -1,7 +1,6 @@
 import aws4_request
 import gleam/http
 import gleam/http/request
-import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 


### PR DESCRIPTION
Hi i've been using gleam in lambda functions and this library is really helpful, submitting this pr to help people developing in a 100% node environment.

+ add javascript now ffi function so package can be used in node only lambda environment 
+ remove unused Option and Some type as prompted by linter
+ Add badge to show that module is supported on both Erlang and Javascript runtimes

Before:
<img width="814" alt="Screenshot 2024-11-23 at 13 00 21" src="https://github.com/user-attachments/assets/9addf719-34b0-474e-8b45-4a78e8841e20">


After:
<img width="586" alt="Screenshot 2024-11-23 at 13 05 20" src="https://github.com/user-attachments/assets/3c94b76d-d16e-4eaf-91f6-e9240970f7ab">
